### PR TITLE
fix: 修复左键点击托盘图标时菜单闪烁问题

### DIFF
--- a/src-tauri/src/tray/mod.rs
+++ b/src-tauri/src/tray/mod.rs
@@ -36,6 +36,7 @@ pub fn setup_tray<R: Runtime>(app: &AppHandle<R>) -> Result<(), Box<dyn std::err
     let _tray = TrayIconBuilder::with_id("main-tray")
         .icon(icon)
         .menu(&menu)
+        .show_menu_on_left_click(false)
         .tooltip("ElegantClipboard")
         .on_menu_event(move |app, event| {
             handle_menu_event(app, event.id.as_ref());


### PR DESCRIPTION
添加 show_menu_on_left_click(false) 禁用左键点击显示菜单，
左键点击现在只切换窗口显示/隐藏，右键点击显示上下文菜单。