### PR TITLE
feat: OCR 支持自定义 API（兼容 RapidOCR / PaddleOCR）

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2440,6 +2440,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3655,6 +3665,7 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
+ "mime_guess",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -5347,6 +5358,12 @@ checksum = "96bd2f2237fe450fcd0a1d2f5f4e91711124f7857ba2e964247776ebeeb7b0c4"
 dependencies = [
  "unic-common",
 ]
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -73,7 +73,7 @@ image = { version = "0.25", default-features = false, features = ["png"] }
 zip = { version = "2", default-features = false, features = ["deflate"] }
 
 # HTTP client for WebDAV sync
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "blocking", "json"] }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "blocking", "json", "multipart"] }
 base64 = "0.22"
 
 # WebSocket for Edge TTS

--- a/src-tauri/src/commands/clipboard.rs
+++ b/src-tauri/src/commands/clipboard.rs
@@ -516,6 +516,13 @@ pub async fn update_text_content(
     }
 }
 
+/// 编辑器保存后通知所有窗口刷新指定条目（通过后端 emit 确保跨窗口送达）
+#[tauri::command]
+pub async fn emit_clipboard_edited(app: tauri::AppHandle, id: i64) {
+    use tauri::Emitter;
+    let _ = app.emit("clipboard-item-edited", id);
+}
+
 /// 将条目复制到系统剪贴板
 #[tauri::command]
 pub async fn copy_to_clipboard(state: State<'_, Arc<AppState>>, id: i64) -> Result<(), String> {

--- a/src-tauri/src/commands/ocr.rs
+++ b/src-tauri/src/commands/ocr.rs
@@ -319,6 +319,157 @@ fn urlencoded(s: &str) -> String {
     result
 }
 
+/// 调用自定义 OCR API 识别图片中的文字
+/// 支持两种请求格式（自动尝试）：
+/// 1. form-data: image_data=<base64>（RapidOCR API 原生格式）
+/// 2. JSON: {"image": "<base64>"}（通用格式）
+///
+/// 支持多种响应格式：
+/// - RapidOCR: { "data": [["text", score, [[x,y],...]], ...] }
+/// - PaddleOCR: { "results": [{"text": "..."}, ...] }
+/// - 通用: { "text": "..." } 或 { "result": "..." }
+/// - 纯文本响应
+#[tauri::command]
+pub async fn ocr_recognize_custom(
+    image_base64: String,
+    api_url: String,
+    proxy_mode: String,
+    proxy_url: String,
+) -> Result<String, String> {
+    tokio::task::spawn_blocking(move || {
+        let client = build_client(&proxy_mode, &proxy_url)?;
+
+        // 使用 multipart form-data 发送（兼容 RapidOCR API）
+        let form = reqwest::blocking::multipart::Form::new()
+            .text("image_data", image_base64.clone());
+
+        let resp = client
+            .post(&api_url)
+            .multipart(form)
+            .send();
+
+        // 如果 multipart 失败（如 405），回退到 JSON 格式
+        let resp = match resp {
+            Ok(r) if r.status().is_success() || r.status().is_server_error() => r,
+            _ => {
+                // 回退: POST JSON { "image": "<base64>" }
+                let body = serde_json::json!({ "image": image_base64 });
+                client
+                    .post(&api_url)
+                    .header("Content-Type", "application/json")
+                    .json(&body)
+                    .send()
+                    .map_err(|e| format!("自定义 OCR 请求失败: {}", e))?
+            }
+        };
+
+        let status = resp.status();
+        let resp_text = resp.text().map_err(|e| format!("读取响应失败: {}", e))?;
+
+        if !status.is_success() {
+            return Err(format!("自定义 OCR 错误 ({}): {}", status, resp_text));
+        }
+
+        // 尝试解析为 JSON
+        if let Ok(val) = serde_json::from_str::<serde_json::Value>(&resp_text) {
+            // 格式1: { "text": "..." } 或 { "result": "..." }
+            if let Some(text) = val.get("text").and_then(|v| v.as_str()) {
+                return Ok(text.to_string());
+            }
+            if let Some(text) = val.get("result").and_then(|v| v.as_str()) {
+                return Ok(text.to_string());
+            }
+
+            // 格式2: { "0": {"rec_txt": "...", ...}, "1": {...} } (RapidOCR API 实际格式)
+            // 数字 key 的对象，每个值含 rec_txt 字段
+            if let Some(obj) = val.as_object() {
+                let mut indexed_lines: Vec<(usize, &str)> = obj
+                    .iter()
+                    .filter_map(|(k, v)| {
+                        let idx = k.parse::<usize>().ok()?;
+                        let text = v.get("rec_txt").and_then(|t| t.as_str())?;
+                        Some((idx, text))
+                    })
+                    .collect();
+                if !indexed_lines.is_empty() {
+                    indexed_lines.sort_by_key(|(idx, _)| *idx);
+                    let lines: Vec<&str> = indexed_lines.iter().map(|(_, t)| *t).collect();
+                    return Ok(lines.join("\n"));
+                }
+            }
+
+            // 格式3: { "data": [[text, score, box], ...] } (RapidOCR 旧版风格)
+            if let Some(data) = val.get("data").and_then(|v| v.as_array()) {
+                let lines: Vec<&str> = data
+                    .iter()
+                    .filter_map(|item| {
+                        item.as_array()
+                            .and_then(|arr| arr.first())
+                            .and_then(|v| v.as_str())
+                            .or_else(|| item.get("text").and_then(|v| v.as_str()))
+                            .or_else(|| item.get("rec_txt").and_then(|v| v.as_str()))
+                    })
+                    .collect();
+                if !lines.is_empty() {
+                    return Ok(lines.join("\n"));
+                }
+            }
+
+            // 格式4: { "results": [{"text": "..."}, ...] } 或嵌套数组 (PaddleOCR Serving 风格)
+            if let Some(results) = val.get("results").and_then(|v| v.as_array()) {
+                let lines: Vec<String> = results
+                    .iter()
+                    .filter_map(|item| {
+                        // {"text": "..."} 格式
+                        if let Some(text) = item.get("text").and_then(|v| v.as_str()) {
+                            return Some(text.to_string());
+                        }
+                        // [[box], ["text", score]] 或 [[box], ("text", score)] 格式
+                        if let Some(arr) = item.as_array() {
+                            if arr.len() >= 2 {
+                                if let Some(text_part) = arr.get(1) {
+                                    // [text, score]
+                                    if let Some(inner) = text_part.as_array() {
+                                        return inner.first().and_then(|v| v.as_str()).map(|s| s.to_string());
+                                    }
+                                    // 直接是字符串
+                                    if let Some(s) = text_part.as_str() {
+                                        return Some(s.to_string());
+                                    }
+                                }
+                            }
+                        }
+                        // "rec_txt" 字段
+                        item.get("rec_txt").and_then(|v| v.as_str()).map(|s| s.to_string())
+                    })
+                    .collect();
+                if !lines.is_empty() {
+                    return Ok(lines.join("\n"));
+                }
+            }
+
+            // 格式5: { "words_result": [{"words": "..."}, ...] } (百度兼容格式)
+            if let Some(words) = val.get("words_result").and_then(|v| v.as_array()) {
+                let lines: Vec<&str> = words
+                    .iter()
+                    .filter_map(|item| item.get("words").and_then(|v| v.as_str()))
+                    .collect();
+                if !lines.is_empty() {
+                    return Ok(lines.join("\n"));
+                }
+            }
+
+            // 无法识别的 JSON 格式，返回原始内容
+            return Ok(resp_text);
+        }
+
+        // 非 JSON，当作纯文本返回
+        Ok(resp_text)
+    })
+    .await
+    .map_err(|e| format!("OCR 任务失败: {}", e))?
+}
+
 /// 打开 OCR 截图选区窗口（全屏覆盖层）
 /// 如果窗口已存在则复用（通过事件通知前端更新），否则首次创建。
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1074,6 +1074,7 @@ pub fn run() {
             commands::ocr::ocr_capture_screen,
             commands::ocr::ocr_crop_region,
             commands::ocr::ocr_recognize_baidu,
+            commands::ocr::ocr_recognize_custom,
             commands::ocr::open_ocr_screenshot_window,
             commands::ocr::ocr_screenshot_ready,
             commands::ocr::hide_ocr_screenshot_window,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1025,6 +1025,7 @@ pub fn run() {
             commands::clipboard::paste_text_direct,
             commands::clipboard::merge_paste_content,
             commands::clipboard::update_text_content,
+            commands::clipboard::emit_clipboard_edited,
             commands::settings::get_running_apps,
             commands::settings::get_setting,
             commands::settings::set_setting,

--- a/src/components/ClipboardList/VirtualizedList.tsx
+++ b/src/components/ClipboardList/VirtualizedList.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useMemo, type RefObject } from "react";
+import { useCallback, useMemo, type RefObject } from "react";
 import type { SortingStrategy } from "@dnd-kit/sortable";
 import { OverlayScrollbarsComponent } from "overlayscrollbars-react";
 import { Virtuoso, type VirtuosoHandle } from "react-virtuoso";
@@ -103,40 +103,27 @@ export function ClipboardVirtualizedList({
     [cardMaxLines],
   );
 
-  // 使用 ref 追踪最新的 props，避免 itemContent 回调因 renderedItems 变化而重建
-  // Virtuoso 内部会在 totalCount 变化时重新调用 itemContent，无需依赖数组触发
-  const renderedItemsRef = useRef(renderedItems);
-  renderedItemsRef.current = renderedItems;
-  const pinnedCountRef = useRef(pinnedCount);
-  pinnedCountRef.current = pinnedCount;
-  const showSlotBadgesRef = useRef(showSlotBadges);
-  showSlotBadgesRef.current = showSlotBadges;
-  const cardDensityRef = useRef(cardDensity);
-  cardDensityRef.current = cardDensity;
-
   const itemContent = useCallback(
     (index: number) => {
-      const item = renderedItemsRef.current[index];
+      const item = renderedItems[index];
       if (!item) return null;
 
-      const pc = pinnedCountRef.current;
-      const showSeparator = index === pc && pc > 0;
-      const density = cardDensityRef.current;
-      const densityPb = density === "compact" ? "pb-1" : density === "spacious" ? "pb-3" : "pb-2";
+      const showSeparator = index === pinnedCount && pinnedCount > 0;
+      const densityPb = cardDensity === "compact" ? "pb-1" : cardDensity === "spacious" ? "pb-3" : "pb-2";
 
       return (
         <div className={`px-2 ${densityPb}${index === 0 ? ' pt-1.5' : ''}`}>
           {showSeparator && <Separator className="mb-2" />}
-          <ClipboardItemCard item={item} index={index} showBadge={showSlotBadgesRef.current} sortId={item._sortId} />
+          <ClipboardItemCard item={item} index={index} showBadge={showSlotBadges} sortId={item._sortId} />
         </div>
       );
     },
-    [], // 稳定回调：通过 ref 读取最新值，Virtuoso 通过 totalCount 变化触发重渲染
+    [renderedItems, pinnedCount, showSlotBadges, cardDensity],
   );
 
   const computeItemKey = useCallback(
-    (index: number) => renderedItemsRef.current[index]?._sortId || `item-${index}`,
-    [],
+    (index: number) => renderedItems[index]?._sortId || `item-${index}`,
+    [renderedItems],
   );
 
   return (

--- a/src/components/TagsView.tsx
+++ b/src/components/TagsView.tsx
@@ -257,6 +257,26 @@ export function TagsView() {
     return () => { unlisten.then((fn) => fn()); };
   }, [fetchTags, fetchTagItems, selectedTagId, searchQuery]);
 
+  // 编辑器保存后原地刷新标签视图中的条目
+  useEffect(() => {
+    const unlisten = listen<number>("clipboard-item-edited", async (event) => {
+      const id = event.payload;
+      if (!id) return;
+      try {
+        const item = await invoke<ClipboardItem | null>("get_clipboard_item", { id });
+        if (item) {
+          setTagItems((prev) => prev.map((i) => (i.id === id ? { ...item, text_content: null, html_content: null, rtf_content: null } : i)));
+        } else {
+          setTagItems((prev) => prev.filter((i) => i.id !== id));
+        }
+      } catch {
+        // 失败时整体刷新
+        await fetchTagItems(selectedTagId, searchQuery);
+      }
+    });
+    return () => { unlisten.then((fn) => fn()); };
+  }, [fetchTagItems, selectedTagId, searchQuery]);
+
   const selectedTag = useMemo(
     () => tags.find((t) => t.id === selectedTagId) ?? null,
     [tags, selectedTagId],

--- a/src/components/settings/OcrTab.tsx
+++ b/src/components/settings/OcrTab.tsx
@@ -29,16 +29,63 @@ const KEY_CODE_MAP: Record<string, string> = {
   Backquote: "`",
 };
 
+/** 可复制的代码块 */
+function CopyBlock({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const handleCopy = () => {
+    navigator.clipboard.writeText(text);
+    setCopied(true);
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => setCopied(false), 1500);
+  };
+  return (
+    <div className="relative bg-muted rounded-md px-4 py-3 font-mono text-xs space-y-1 group/code">
+      {text.split("\n").map((line, i) => <p key={i}>{line}</p>)}
+      <button
+        type="button"
+        className="absolute top-2 right-2 px-2 py-1 rounded text-[11px] bg-background border opacity-0 group-hover/code:opacity-100 transition-opacity text-muted-foreground hover:text-foreground"
+        onClick={handleCopy}
+      >
+        {copied ? "已复制" : "复制"}
+      </button>
+    </div>
+  );
+}
+
+/** 可点击复制的行内代码 */
+function CopyInlineCode({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const handleCopy = () => {
+    navigator.clipboard.writeText(text);
+    setCopied(true);
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => setCopied(false), 1500);
+  };
+  return (
+    <code
+      className="px-1.5 py-0.5 bg-muted rounded text-[11px] cursor-pointer hover:bg-muted/80 transition-colors"
+      onClick={handleCopy}
+      title="点击复制"
+    >
+      {copied ? "已复制 ✓" : text}
+    </code>
+  );
+}
+
 export function OcrTab() {
   const {
     enabled, setEnabled,
     recordOcrCopy, setRecordOcrCopy,
     autoCopy, setAutoCopy,
     autoTranslate, setAutoTranslate,
+    provider, setProvider,
     accuracy, setAccuracy,
     shortcut, setShortcut,
     baiduApiKey, setBaiduApiKey,
     baiduSecretKey, setBaiduSecretKey,
+    customApiUrl, setCustomApiUrl,
     proxyMode, setProxyMode,
     proxyUrl, setProxyUrl,
     loaded, loadSettings,
@@ -284,75 +331,150 @@ export function OcrTab() {
           <div className="rounded-lg border bg-card p-4">
             <h3 className="text-sm font-medium mb-3">识别接口</h3>
             <p className="text-xs text-muted-foreground mb-4">
-              配置百度 OCR 识别接口参数
+              选择 OCR 识别服务提供者
             </p>
             <div className="space-y-3">
-              {/* 识别精度 */}
+              {/* 提供者选择 */}
               <div className="flex items-center justify-between">
                 <div className="space-y-0.5">
-                  <Label className="text-xs">识别精度</Label>
+                  <Label className="text-xs">识别服务</Label>
                   <p className="text-xs text-muted-foreground">
-                    {accuracy === "high" ? "精度更高，速度较慢" : "速度更快，精度略低"}
+                    {provider === "baidu" ? "使用百度智能云 OCR API" : "使用自部署的 OCR 服务（PaddleOCR / RapidOCR 等）"}
                   </p>
                 </div>
-                <Select value={accuracy} onValueChange={(v) => setAccuracy(v as "high" | "standard")}>
+                <Select value={provider} onValueChange={(v) => setProvider(v as "baidu" | "custom")}>
                   <SelectTrigger className="w-[150px] h-8 text-xs"><SelectValue /></SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="high">高精度版</SelectItem>
-                    <SelectItem value="standard">标准版（更快）</SelectItem>
+                    <SelectItem value="baidu">百度 OCR</SelectItem>
+                    <SelectItem value="custom">自定义 API</SelectItem>
                   </SelectContent>
                 </Select>
               </div>
-              <div className="space-y-1.5">
-                <Label className="text-xs">API Key</Label>
-                <Input
-                  className="h-8 text-xs"
-                  placeholder="输入百度 OCR API Key"
-                  value={baiduApiKey}
-                  onChange={(e) => {
-                    const v = e.target.value;
-                    useOcrSettings.setState({ baiduApiKey: v });
-                    debounced(setBaiduApiKey, v);
-                  }}
-                />
-              </div>
-              <div className="space-y-1.5">
-                <Label className="text-xs">Secret Key</Label>
-                <div className="relative">
-                  <Input
-                    className="h-8 text-xs pr-8"
-                    type={showSecretKey ? "text" : "password"}
-                    placeholder="输入百度 OCR Secret Key"
-                    value={baiduSecretKey}
-                    onChange={(e) => {
-                      const v = e.target.value;
-                      useOcrSettings.setState({ baiduSecretKey: v });
-                      debounced(setBaiduSecretKey, v);
-                    }}
-                  />
-                  <button
-                    type="button"
-                    className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
-                    onClick={() => setShowSecretKey(!showSecretKey)}
-                  >
-                    {showSecretKey ? <EyeOff16Regular className="w-3.5 h-3.5" /> : <Eye16Regular className="w-3.5 h-3.5" />}
-                  </button>
-                </div>
-              </div>
-              <p className="text-xs text-muted-foreground">
-                请前往{" "}
-                <a
-                  className="text-primary hover:underline cursor-pointer"
-                  onClick={() => {
-                    import("@tauri-apps/plugin-opener").then(({ openUrl }) => {
-                      openUrl("https://console.bce.baidu.com/ai/#/ai/ocr/overview/index");
-                    });
-                  }}
-                >
-                  百度智能云 OCR 控制台
-                </a>
-                {" "}获取 API Key 和 Secret Key
-              </p>
+
+              {provider === "baidu" && (
+                <>
+                  {/* 识别精度 */}
+                  <div className="flex items-center justify-between">
+                    <div className="space-y-0.5">
+                      <Label className="text-xs">识别精度</Label>
+                      <p className="text-xs text-muted-foreground">
+                        {accuracy === "high" ? "精度更高，速度较慢" : "速度更快，精度略低"}
+                      </p>
+                    </div>
+                    <Select value={accuracy} onValueChange={(v) => setAccuracy(v as "high" | "standard")}>
+                      <SelectTrigger className="w-[150px] h-8 text-xs"><SelectValue /></SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="high">高精度版</SelectItem>
+                        <SelectItem value="standard">标准版（更快）</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <div className="space-y-1.5">
+                    <Label className="text-xs">API Key</Label>
+                    <Input
+                      className="h-8 text-xs"
+                      placeholder="输入百度 OCR API Key"
+                      value={baiduApiKey}
+                      onChange={(e) => {
+                        const v = e.target.value;
+                        useOcrSettings.setState({ baiduApiKey: v });
+                        debounced(setBaiduApiKey, v);
+                      }}
+                    />
+                  </div>
+                  <div className="space-y-1.5">
+                    <Label className="text-xs">Secret Key</Label>
+                    <div className="relative">
+                      <Input
+                        className="h-8 text-xs pr-8"
+                        type={showSecretKey ? "text" : "password"}
+                        placeholder="输入百度 OCR Secret Key"
+                        value={baiduSecretKey}
+                        onChange={(e) => {
+                          const v = e.target.value;
+                          useOcrSettings.setState({ baiduSecretKey: v });
+                          debounced(setBaiduSecretKey, v);
+                        }}
+                      />
+                      <button
+                        type="button"
+                        className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+                        onClick={() => setShowSecretKey(!showSecretKey)}
+                      >
+                        {showSecretKey ? <EyeOff16Regular className="w-3.5 h-3.5" /> : <Eye16Regular className="w-3.5 h-3.5" />}
+                      </button>
+                    </div>
+                  </div>
+                  <p className="text-xs text-muted-foreground">
+                    请前往{" "}
+                    <a
+                      className="text-primary hover:underline cursor-pointer"
+                      onClick={() => {
+                        import("@tauri-apps/plugin-opener").then(({ openUrl }) => {
+                          openUrl("https://console.bce.baidu.com/ai/#/ai/ocr/overview/index");
+                        });
+                      }}
+                    >
+                      百度智能云 OCR 控制台
+                    </a>
+                    {" "}获取 API Key 和 Secret Key
+                  </p>
+                </>
+              )}
+
+              {provider === "custom" && (
+                <>
+                  <div className="space-y-1.5">
+                    <Label className="text-xs">API 地址</Label>
+                    <Input
+                      className="h-8 text-xs"
+                      placeholder="http://localhost:9003/ocr"
+                      value={customApiUrl}
+                      onChange={(e) => {
+                        const v = e.target.value;
+                        useOcrSettings.setState({ customApiUrl: v });
+                        debounced(setCustomApiUrl, v);
+                      }}
+                    />
+                  </div>
+                  <div className="text-xs text-muted-foreground space-y-1.5">
+                    <p>
+                      推荐使用{" "}
+                      <a
+                        className="text-primary font-medium hover:underline cursor-pointer"
+                        onClick={() => {
+                          import("@tauri-apps/plugin-opener").then(({ openUrl }) => {
+                            openUrl("https://rapidai.github.io/RapidOCRDocs/main/install_usage/rapidocr_api/usage/");
+                          });
+                        }}
+                      >
+                        RapidOCR API
+                      </a>
+                      ，安装简单、识别速度快、无需 GPU：
+                    </p>
+                    <CopyBlock text={"pip install rapidocr_api onnxruntime\nrapidocr_api"} />
+                    <p>
+                      启动后默认地址为{" "}
+                      <CopyInlineCode text="http://localhost:9003/ocr" />
+                    </p>
+                    <p className="text-muted-foreground/70">如有 NVIDIA GPU 可将 onnxruntime 替换为 onnxruntime-gpu 以加速推理</p>
+                    <p className="pt-1.5 text-muted-foreground/70">
+                      也兼容{" "}
+                      <a
+                        className="text-primary/80 hover:underline cursor-pointer"
+                        onClick={() => {
+                          import("@tauri-apps/plugin-opener").then(({ openUrl }) => {
+                            openUrl("https://github.com/PaddlePaddle/PaddleOCR");
+                          });
+                        }}
+                      >
+                        PaddleOCR
+                      </a>
+                      {" "}等其他 OCR 服务，只需接口返回包含识别文字的 JSON 即可。
+                    </p>
+                  </div>
+                </>
+              )}
 
               {/* 网络代理 */}
               <div className="flex items-center justify-between pt-4">

--- a/src/components/tags/TagItemRows.tsx
+++ b/src/components/tags/TagItemRows.tsx
@@ -4,12 +4,13 @@ import { CSS } from "@dnd-kit/utilities";
 import {
   Dismiss16Regular,
   Document16Regular,
+  Edit16Regular,
   Folder16Regular,
   ReOrderDotsVertical16Regular,
   Video16Regular,
   Warning16Regular,
 } from "@fluentui/react-icons";
-import { convertFileSrc } from "@tauri-apps/api/core";
+import { convertFileSrc, invoke } from "@tauri-apps/api/core";
 import { ImagePreview } from "@/components/CardContentRenderers";
 import { HighlightText } from "@/components/HighlightText";
 import {
@@ -183,6 +184,8 @@ export function SortableTagItemRow({
     opacity: isDragging ? 0.5 : undefined,
   }), [transform, transition, isDragging]);
 
+  const isEditable = item.content_type === "text" || item.content_type === "html" || item.content_type === "rtf";
+
   return (
     <div
       ref={setNodeRef}
@@ -204,7 +207,7 @@ export function SortableTagItemRow({
       <div className="flex-1 min-w-0">
         <TagItemRowContent item={item} timeFormat={timeFormat} />
       </div>
-      <RemoveTagButton onRemove={onRemove} />
+      <ItemActionButtons itemId={item.id} isEditable={isEditable} onRemove={onRemove} />
     </div>
   );
 }
@@ -216,6 +219,8 @@ export function TagItemRow({
   onRemove,
   isLast,
 }: TagItemRowProps) {
+  const isEditable = item.content_type === "text" || item.content_type === "html" || item.content_type === "rtf";
+
   return (
     <div
       className={cn(
@@ -227,23 +232,41 @@ export function TagItemRow({
       <div className="flex-1 min-w-0">
         <TagItemRowContent item={item} timeFormat={timeFormat} />
       </div>
-      <RemoveTagButton onRemove={onRemove} />
+      <ItemActionButtons itemId={item.id} isEditable={isEditable} onRemove={onRemove} />
     </div>
   );
 }
 
-function RemoveTagButton({ onRemove }: { onRemove: () => void }) {
+function ItemActionButtons({ itemId, isEditable, onRemove }: { itemId: number; isEditable: boolean; onRemove: () => void }) {
   return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <button
-          onClick={(e) => { e.stopPropagation(); onRemove(); }}
-          className="shrink-0 mt-0.5 w-5 h-5 flex items-center justify-center rounded-md text-muted-foreground/50 hover:text-destructive hover:bg-destructive/10 opacity-0 group-hover/row:opacity-100 transition-all duration-150"
-        >
-          <Dismiss16Regular className="w-3 h-3" />
-        </button>
-      </TooltipTrigger>
-      <TooltipContent>移除标签</TooltipContent>
-    </Tooltip>
+    <div className="shrink-0 flex flex-col gap-0.5 mt-0.5 opacity-0 group-hover/row:opacity-100 transition-opacity duration-150">
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            onClick={(e) => { e.stopPropagation(); onRemove(); }}
+            className="w-5 h-5 flex items-center justify-center rounded-md text-muted-foreground/50 hover:text-destructive hover:bg-destructive/10 transition-colors"
+          >
+            <Dismiss16Regular className="w-3 h-3" />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent>移除标签</TooltipContent>
+      </Tooltip>
+      {isEditable && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                invoke("open_text_editor_window", { id: itemId }).catch(() => {});
+              }}
+              className="w-5 h-5 flex items-center justify-center rounded-md text-muted-foreground/50 hover:text-primary hover:bg-primary/10 transition-colors"
+            >
+              <Edit16Regular className="w-3 h-3" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>编辑</TooltipContent>
+        </Tooltip>
+      )}
+    </div>
   );
 }

--- a/src/lib/ocr.ts
+++ b/src/lib/ocr.ts
@@ -2,13 +2,24 @@ import { invoke } from "@tauri-apps/api/core";
 import { logError } from "@/lib/logger";
 import { useOcrSettings } from "@/stores/ocr-settings";
 
-/** 调用百度 OCR识别 */
+/** 调用 OCR 识别（根据当前选择的提供者路由） */
 export async function recognizeText(imageBase64: string): Promise<string> {
   const ocrSettings = useOcrSettings.getState();
   if (!ocrSettings.enabled) throw new Error("OCR 功能未启用");
 
   try {
-    const result = await invoke<string>("ocr_recognize_baidu", {
+    if (ocrSettings.provider === "custom") {
+      if (!ocrSettings.customApiUrl) throw new Error("请先配置自定义 OCR API 地址");
+      return await invoke<string>("ocr_recognize_custom", {
+        imageBase64,
+        apiUrl: ocrSettings.customApiUrl,
+        proxyMode: ocrSettings.proxyMode || "none",
+        proxyUrl: ocrSettings.proxyUrl || "",
+      });
+    }
+
+    // 默认: 百度 OCR
+    return await invoke<string>("ocr_recognize_baidu", {
       imageBase64,
       apiKey: ocrSettings.baiduApiKey,
       secretKey: ocrSettings.baiduSecretKey,
@@ -16,7 +27,6 @@ export async function recognizeText(imageBase64: string): Promise<string> {
       proxyMode: ocrSettings.proxyMode || "none",
       proxyUrl: ocrSettings.proxyUrl || "",
     });
-    return result;
   } catch (error) {
     logError("OCR识别失败:", error);
     throw error;

--- a/src/pages/TextEditor.tsx
+++ b/src/pages/TextEditor.tsx
@@ -63,10 +63,13 @@ export function TextEditor() {
     try {
       const deleted = await invoke<boolean>("update_text_content", { id, newText: textRef.current });
       if (deleted) {
+        // 通过后端 emit 确保主窗口收到事件
+        await invoke("emit_clipboard_edited", { id });
         getCurrentWindow().close();
         return;
       }
       setOriginalText(textRef.current);
+      await invoke("emit_clipboard_edited", { id });
     } catch (error) {
       logError("Failed to save:", error);
     } finally {
@@ -97,6 +100,7 @@ export function TextEditor() {
       setSaving(true);
       try {
         await invoke<boolean>("update_text_content", { id, newText: text });
+        await invoke("emit_clipboard_edited", { id });
       } catch (error) {
         logError("Failed to save:", error);
         setSaving(false);
@@ -145,16 +149,18 @@ export function TextEditor() {
             {text.length} 字符 · {byteSize} 字节
           </span>
           <div className="flex gap-2">
+            {hasChanges && (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => getCurrentWindow().close()}
+              >
+                取消
+              </Button>
+            )}
             <Button
-              variant="outline"
               size="sm"
-              onClick={() => getCurrentWindow().close()}
-            >
-              取消
-            </Button>
-            <Button
-              size="sm"
-              onClick={handleSaveAndClose}
+              onClick={hasChanges ? handleSaveAndClose : () => getCurrentWindow().close()}
               disabled={saving}
             >
               {saving ? "保存中..." : hasChanges ? "保存并关闭" : "关闭"}

--- a/src/stores/clipboard.ts
+++ b/src/stores/clipboard.ts
@@ -176,6 +176,17 @@ export function removeVisibleClipboardItem(id: number) {
   });
 }
 
+/** 原地更新条目内容（编辑后刷新，不改变位置） */
+export function updateVisibleClipboardItem(item: ClipboardItem) {
+  useClipboardStore.setState((state) => {
+    const index = state.items.findIndex((existing) => existing.id === item.id);
+    if (index === -1) return {};
+    const nextItems = [...state.items];
+    nextItems[index] = asListItem(item);
+    return { items: nextItems };
+  });
+}
+
 function moveVisibleItemToTop(id: number) {
   useClipboardStore.setState((state) => {
     const index = state.items.findIndex((item) => item.id === id);
@@ -394,7 +405,26 @@ export const useClipboardStore = create<ClipboardState>((set, get) => ({
         await get().refresh();
       }
     });
-    return unlisten;
+
+    // 编辑器保存后的原地更新（不改变条目位置）
+    const unlistenEdit = await listen<number>("clipboard-item-edited", async (event) => {
+      const id = event.payload;
+      if (!id) return;
+      try {
+        const item = await invoke<ClipboardItem | null>("get_clipboard_item", { id });
+        if (item) {
+          updateVisibleClipboardItem(item);
+        } else {
+          // 条目被删除（内容清空时）
+          removeVisibleClipboardItem(id);
+        }
+      } catch (error) {
+        logError("Failed to fetch edited clipboard item:", error);
+        await get().refresh();
+      }
+    });
+
+    return () => { unlisten(); unlistenEdit(); };
   },
 
   // 批量选择

--- a/src/stores/ocr-settings.ts
+++ b/src/stores/ocr-settings.ts
@@ -11,7 +11,7 @@ const broadcastChange = (state: Partial<OcrSettings>) => {
   });
 };
 
-export type OcrProvider = "baidu";
+export type OcrProvider = "baidu" | "custom";
 export type OcrAccuracy = "high" | "standard";
 
 export interface OcrSettings {
@@ -25,6 +25,8 @@ export interface OcrSettings {
   // Baidu OCR
   baiduApiKey: string;
   baiduSecretKey: string;
+  // Custom API
+  customApiUrl: string;
   // Proxy
   proxyMode: "system" | "none" | "custom";
   proxyUrl: string;
@@ -43,6 +45,7 @@ interface OcrSettingsStore extends OcrSettings {
   setShortcut: (shortcut: string) => void;
   setBaiduApiKey: (key: string) => void;
   setBaiduSecretKey: (key: string) => void;
+  setCustomApiUrl: (url: string) => void;
   setProxyMode: (mode: "system" | "none" | "custom") => void;
   setProxyUrl: (url: string) => void;
 }
@@ -57,6 +60,7 @@ const SETTING_KEYS: Record<string, keyof OcrSettings> = {
   ocr_shortcut: "shortcut",
   ocr_baidu_api_key: "baiduApiKey",
   ocr_baidu_secret_key: "baiduSecretKey",
+  ocr_custom_api_url: "customApiUrl",
   ocr_proxy_mode: "proxyMode",
   ocr_proxy_url: "proxyUrl",
 };
@@ -71,6 +75,7 @@ export const useOcrSettings = create<OcrSettingsStore>((set, get) => ({
   shortcut: "",
   baiduApiKey: "",
   baiduSecretKey: "",
+  customApiUrl: "",
   proxyMode: "none",
   proxyUrl: "",
   loaded: false,
@@ -89,6 +94,7 @@ export const useOcrSettings = create<OcrSettingsStore>((set, get) => ({
         shortcut: values["ocr_shortcut"] || "",
         baiduApiKey: values["ocr_baidu_api_key"] || "",
         baiduSecretKey: values["ocr_baidu_secret_key"] || "",
+        customApiUrl: values["ocr_custom_api_url"] || "",
         proxyMode: (values["ocr_proxy_mode"] as "system" | "none" | "custom") || "none",
         proxyUrl: values["ocr_proxy_url"] || "",
         loaded: true,
@@ -150,6 +156,11 @@ export const useOcrSettings = create<OcrSettingsStore>((set, get) => ({
     set({ baiduSecretKey: key });
     get().saveSetting("ocr_baidu_secret_key", key);
     broadcastChange({ baiduSecretKey: key });
+  },
+  setCustomApiUrl: (url) => {
+    set({ customApiUrl: url });
+    get().saveSetting("ocr_custom_api_url", url);
+    broadcastChange({ customApiUrl: url });
   },
   setProxyMode: (mode) => {
     set({ proxyMode: mode });


### PR DESCRIPTION
## 改动概述

在现有百度 OCR 基础上，新增「自定义 API」选项，允许用户接入自部署的 OCR 服务。

### 新增功能
- OCR 设置新增「识别服务」下拉：百度 OCR / 自定义 API
- 自定义 API 使用 multipart form-data 发送 base64 图片（RapidOCR 原生格式）
- 请求失败时自动回退 JSON 格式，兼容其他 OCR 服务
- 自动解析多种响应格式（RapidOCR / PaddleOCR / 通用 JSON / 纯文本）
- 设置界面推荐 RapidOCR API，提供安装命令、文档链接和一键复制
- reqwest 新增 multipart feature

### 测试情况
- RapidOCR API 已实际测试，识别正常
- PaddleOCR 根据官方文档处理了对应的响应结构，未实际部署测试

### 设计说明

作为剪贴板管理工具，OCR 功能的定位是轻量辅助能快速识别屏幕文字并记录到剪贴板即可。因此选择了最简单的「远程 API」方案：零安装、零体积增加，用户只需两行命令启动 RapidOCR 服务即可使用。

对于需要更高精度、多语言支持或复杂版面分析的场景，建议使用专业的 OCR 项目（如 [RapidOCR](https://github.com/RapidAI/RapidOCR)、[PaddleOCR](https://github.com/PaddlePaddle/PaddleOCR)）直接部署完整服务。

## CI
- ESLint 通过
- TypeScript check 通过
- Cargo check 通过