### PR TITLE
fix: 修复标签重命名对话框无法输入的问题

### DIFF
--- a/src/components/TagsView.tsx
+++ b/src/components/TagsView.tsx
@@ -141,6 +141,7 @@ export function TagsView() {
   const [isCreating, setIsCreating] = useState(false);
   const [createName, setCreateName] = useState("");
   const createInputRef = useRef<HTMLInputElement>(null);
+  const renameInputRef = useRef<HTMLInputElement>(null);
 
   // Dialogs
   const [renameOpen, setRenameOpen] = useState(false);
@@ -622,14 +623,15 @@ export function TagsView() {
 
       {/* Rename tag dialog */}
       <Dialog open={renameOpen} onOpenChange={(o) => { setRenameOpen(o); if (!o) setRenameTarget(null); }}>
-        <DialogContent showCloseButton={false}>
+        <DialogContent showCloseButton={false} onOpenAutoFocus={(e) => { e.preventDefault(); focusWindowImmediately().then(() => renameInputRef.current?.focus()); }}>
           <DialogHeader className="text-left"><DialogTitle>重命名标签</DialogTitle></DialogHeader>
           <Input
+            ref={renameInputRef}
             placeholder="标签名称"
             value={renameName}
             onChange={(e) => setRenameName(e.target.value)}
+            onFocus={() => focusWindowImmediately()}
             onKeyDown={(e) => { if (e.key === "Enter") handleRename(); }}
-            autoFocus
           />
           <DialogFooter>
             <Button variant="outline" onClick={() => setRenameOpen(false)}>取消</Button>


### PR DESCRIPTION
## 问题描述

在标签管理页面右键重命名标签时，有时候对话框的输入框无法接收键盘输入（无法修改和删除内容）。

## 原因分析

主窗口设置为 `focusable(false)` 以避免抢占其他应用焦点。重命名对话框的 Input 使用 `autoFocus`，但在这种模式下 `autoFocus` 不可靠浏览器认为输入框已聚焦（视觉上有光标），但操作系统层面窗口未获得键盘焦点，导致按键事件不会送达输入框。

## 修复方案

1. 用 `onOpenAutoFocus` 拦截对话框的自动聚焦行为，改为先调用 `focusWindowImmediately()`（临时启用窗口焦点），再手动聚焦输入框
2. 添加 `onFocus` 回调作为兜底（用户点击输入框时也能恢复焦点）
3. 移除不可靠的 `autoFocus` 属性